### PR TITLE
Add Electron desktop app for textile cleaning

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,3 @@
+dist/
+dist-electron/
+node_modules/

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,0 +1,76 @@
+import { app, BrowserWindow, ipcMain, dialog } from 'electron'
+import path from 'path'
+import { URL } from 'url'
+
+const isDev = process.env.NODE_ENV === 'development'
+
+let mainWindow: BrowserWindow | null = null
+
+const createWindow = async (): Promise<void> => {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    backgroundColor: '#121212',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false
+    }
+  })
+
+  const pageUrl = isDev
+    ? new URL(path.join(__dirname, '../index.html'), 'file:').toString()
+    : new URL(path.join(__dirname, '../index.html'), 'file:').toString()
+  await mainWindow.loadURL(pageUrl)
+
+  if (isDev) {
+    mainWindow.webContents.openDevTools({ mode: 'detach' })
+  }
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.whenReady().then(async () => {
+  await createWindow()
+
+  app.on('activate', async () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      await createWindow()
+    }
+  })
+})
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+ipcMain.handle('printer:list', async () => {
+  if (mainWindow == null) return []
+  return mainWindow.webContents.getPrintersAsync()
+})
+
+ipcMain.handle('printer:print', async (_event, options: Electron.WebContentsPrintOptions) => {
+  if (mainWindow == null) {
+    throw new Error('Printer is not available without an open window')
+  }
+
+  return await new Promise<boolean>((resolve, reject) => {
+    mainWindow?.webContents.print(options, (success, reason) => {
+      if (!success) {
+        reject(new Error(reason))
+      } else {
+        resolve(true)
+      }
+    })
+  })
+})
+
+ipcMain.handle('dialog:showError', async (_event, message: string) => {
+  if (mainWindow == null) return
+  await dialog.showErrorBox('Textilreinigung Ettlingen', message)
+})

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -1,0 +1,19 @@
+import { contextBridge, ipcRenderer } from 'electron'
+
+type PrinterOptions = Electron.WebContentsPrintOptions
+
+declare global {
+  interface Window {
+    electron: {
+      listPrinters: () => Promise<Electron.PrinterInfo[]>
+      print: (options: PrinterOptions) => Promise<boolean>
+      showError: (message: string) => Promise<void>
+    }
+  }
+}
+
+contextBridge.exposeInMainWorld('electron', {
+  listPrinters: async () => await ipcRenderer.invoke('printer:list'),
+  print: async (options: PrinterOptions) => await ipcRenderer.invoke('printer:print', options),
+  showError: async (message: string) => await ipcRenderer.invoke('dialog:showError', message)
+})

--- a/app/electron/tsconfig.json
+++ b/app/electron/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.node.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "../dist-electron"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Textilreinigung Ettlingen Desktop</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./dist/main.js"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "textilreinigung-ettlingen-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist-electron/main.js",
+  "type": "module",
+  "scripts": {
+    "dev": "npm run build:ts && NODE_ENV=development electron .",
+    "build": "npm run build:ts && npm run build:electron",
+    "build:ts": "tsc",
+    "build:electron": "tsc -p electron/tsconfig.json",
+    "test": "npm run build:ts && node --test tests/**/*.test.js"
+  },
+  "dependencies": {
+    "date-fns": "^2.30.0",
+    "firebase": "^10.7.1",
+    "html5-qrcode": "^2.3.8",
+    "qrcode.react": "^3.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.48.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/app/src/components/AppLayout.tsx
+++ b/app/src/components/AppLayout.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import type { ViewKey } from '../modules/App.js'
+import { classNames } from '../utils/classNames.js'
+
+interface AppLayoutProps {
+  activeView: ViewKey
+  onNavigate: (view: ViewKey) => void
+  children: ReactNode
+}
+
+const navItems: Array<{ label: string; key: ViewKey; icon: string }> = [
+  { label: 'Auftragsannahme', key: 'auftragsannahme', icon: '🧾' },
+  { label: 'Auftragsübersicht', key: 'auftragsuebersicht', icon: '📋' },
+  { label: 'Kasse', key: 'kasse', icon: '💶' },
+  { label: 'Reklamationen', key: 'reklamationen', icon: '⚠️' },
+  { label: 'Statistik', key: 'statistik', icon: '📈' }
+]
+
+const AppLayout = ({ activeView, onNavigate, children }: AppLayoutProps): JSX.Element => {
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  return (
+    <div className="app-shell">
+      <aside className={classNames('app-sidebar', menuOpen && 'open')}>
+        <div className="sidebar-header">
+          <span className="sidebar-logo">🧺</span>
+          <div>
+            <h1>Textilreinigung</h1>
+            <p>Ettlingen</p>
+          </div>
+          <button className="sidebar-toggle" onClick={() => setMenuOpen((prev) => !prev)}>
+            ☰
+          </button>
+        </div>
+        <nav>
+          <ul>
+            {navItems.map((item) => (
+              <li key={item.key}>
+                <button
+                  type="button"
+                  className={classNames('nav-link', activeView === item.key && 'active')}
+                  onClick={() => {
+                    onNavigate(item.key)
+                    setMenuOpen(false)
+                  }}
+                >
+                  <span className="nav-icon" aria-hidden>
+                    {item.icon}
+                  </span>
+                  <span>{item.label}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+      <main className="app-content">
+        <header className="app-header">
+          <h2>Willkommen bei Textilreinigung Ettlingen</h2>
+          <p>Touch-optimierte Oberfläche für den schnellen Alltag in der Annahme.</p>
+        </header>
+        <section className="app-view">{children}</section>
+      </main>
+    </div>
+  )
+}
+
+export default AppLayout

--- a/app/src/components/QrScanner.tsx
+++ b/app/src/components/QrScanner.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useMemo } from 'react'
+import { Html5Qrcode } from 'html5-qrcode'
+
+interface QrScannerProps {
+  onResult: (value: string) => void
+}
+
+const QrScanner = ({ onResult }: QrScannerProps): JSX.Element => {
+  const elementId = useMemo(() => `qr-${Math.random().toString(36).slice(2)}`, [])
+
+  useEffect(() => {
+    let scanner: Html5Qrcode | undefined
+    const startScanner = async () => {
+      if (!('mediaDevices' in navigator)) return
+      scanner = new Html5Qrcode(elementId)
+      try {
+        await scanner.start({ facingMode: 'environment' }, { fps: 10, qrbox: 220 }, (decodedText) => {
+          onResult(decodedText)
+        })
+      } catch (error) {
+        console.warn('QR-Scanner konnte nicht gestartet werden', error)
+      }
+    }
+
+    void startScanner()
+
+    return () => {
+      if (scanner != null) {
+        void scanner.stop().finally(() => {
+          scanner?.clear()
+        })
+      }
+    }
+  }, [elementId, onResult])
+
+  return <div id={elementId} style={{ width: '100%' }} />
+}
+
+export default QrScanner

--- a/app/src/hooks/usePrinter.ts
+++ b/app/src/hooks/usePrinter.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from 'react'
+
+type PrinterInfo = { name: string }
+
+declare global {
+  interface Window {
+    electron?: {
+      listPrinters: () => Promise<PrinterInfo[]>
+      print: (options: Electron.WebContentsPrintOptions) => Promise<boolean>
+      showError: (message: string) => Promise<void>
+    }
+  }
+}
+
+export const usePrinter = () => {
+  const [printers, setPrinters] = useState<PrinterInfo[]>([])
+  const [selectedPrinter, setSelectedPrinter] = useState<string>('')
+
+  useEffect(() => {
+    const loadPrinters = async () => {
+      if (window.electron == null) return
+      const list = await window.electron.listPrinters()
+      setPrinters(list)
+      if (list.length > 0) {
+        setSelectedPrinter(list[0].name)
+      }
+    }
+
+    void loadPrinters()
+  }, [])
+
+  const print = useCallback(
+    async (content: string, options?: Partial<Electron.WebContentsPrintOptions>) => {
+      if (window.electron == null) {
+        console.warn('Electron printing bridge not available')
+        return false
+      }
+
+      try {
+        return await window.electron.print({
+          silent: true,
+          deviceName: selectedPrinter,
+          printBackground: true,
+          ...options,
+          pageSize: options?.pageSize ?? 'A4'
+        })
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Unbekannter Fehler'
+        await window.electron.showError?.(message)
+        return false
+      }
+    },
+    [selectedPrinter]
+  )
+
+  return {
+    printers,
+    selectedPrinter,
+    setSelectedPrinter,
+    print
+  }
+}

--- a/app/src/jsx.d.ts
+++ b/app/src/jsx.d.ts
@@ -1,0 +1,6 @@
+declare namespace JSX {
+  interface Element {}
+  interface IntrinsicElements {
+    [elemName: string]: any
+  }
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './modules/App.js'
+import './styles/theme.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/app/src/modules/App.tsx
+++ b/app/src/modules/App.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useMemo, useState } from 'react'
+import AppLayout from '../components/AppLayout.js'
+import OrderIntake from './orders/OrderIntake.js'
+import OrdersOverview from './orders/OrdersOverview.js'
+import CashRegister from './cash/CashRegister.js'
+import ComplaintsModule from './complaints/ComplaintsModule.js'
+import StatisticsModule from './statistics/StatisticsModule.js'
+import { useDataStore } from '../stores/useDataStore.js'
+
+export type ViewKey =
+  | 'auftragsannahme'
+  | 'auftragsuebersicht'
+  | 'kasse'
+  | 'reklamationen'
+  | 'statistik'
+
+const App = (): JSX.Element => {
+  const loadInitialData = useDataStore((state) => state.loadInitialData)
+  const [view, setView] = useState<ViewKey>('auftragsannahme')
+
+  useEffect(() => {
+    void loadInitialData()
+  }, [loadInitialData])
+
+  const content = useMemo(() => {
+    switch (view) {
+      case 'auftragsannahme':
+        return <OrderIntake />
+      case 'auftragsuebersicht':
+        return <OrdersOverview />
+      case 'kasse':
+        return <CashRegister />
+      case 'reklamationen':
+        return <ComplaintsModule />
+      case 'statistik':
+        return <StatisticsModule />
+      default:
+        return null
+    }
+  }, [view])
+
+  return (
+    <AppLayout activeView={view} onNavigate={setView}>
+      {content}
+    </AppLayout>
+  )
+}
+
+export default App

--- a/app/src/modules/cash/CashRegister.tsx
+++ b/app/src/modules/cash/CashRegister.tsx
@@ -1,0 +1,269 @@
+import { useMemo } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import { format } from 'date-fns'
+import { useDataStore } from '../../stores/useDataStore.js'
+import type { PaymentMethod } from '../../types'
+import { formatCurrency } from '../../utils/currency.js'
+
+interface PaymentForm {
+  orderId: string
+  amount: number
+  method: PaymentMethod
+}
+
+interface CashForm {
+  type: 'Einzahlung' | 'Auszahlung'
+  amount: number
+  method: PaymentMethod | 'Sonstiges'
+  note?: string
+}
+
+const paymentMethods: PaymentMethod[] = ['Bar', 'EC', 'Bank', 'Wise', 'Kreditkarte']
+
+const CashRegister = (): JSX.Element => {
+  const orders = useDataStore((state) => state.orders)
+  const payments = useDataStore((state) => state.payments)
+  const cashEntries = useDataStore((state) => state.cashEntries)
+  const recordPayment = useDataStore((state) => state.recordPayment)
+  const addCashEntry = useDataStore((state) => state.addCashEntry)
+  const selectedRegister = useDataStore((state) => state.selectedRegister)
+  const selectRegister = useDataStore((state) => state.selectRegister)
+
+  const { control, handleSubmit, reset } = useForm<PaymentForm>({
+    defaultValues: {
+      method: 'Bar',
+      amount: 0
+    }
+  })
+  const {
+    control: cashControl,
+    handleSubmit: handleCashSubmit,
+    reset: resetCash
+  } = useForm<CashForm>({
+    defaultValues: {
+      type: 'Einzahlung',
+      amount: 0,
+      method: 'Bar',
+      note: ''
+    }
+  })
+
+  const totals = useMemo(() => {
+    const byMethod = paymentMethods.reduce<Record<PaymentMethod, number>>((acc, method) => {
+      acc[method] = payments
+        .filter((payment) => payment.method === method)
+        .reduce((sum, payment) => sum + payment.amount, 0)
+      return acc
+    }, {
+      Bar: 0,
+      EC: 0,
+      Bank: 0,
+      Wise: 0,
+      Kreditkarte: 0
+    })
+
+    const registerTotals = cashEntries.reduce(
+      (acc, entry) => {
+        acc[entry.register] += entry.type === 'Einzahlung' ? entry.amount : -entry.amount
+        return acc
+      },
+      { Hauptkasse: 0, Nebenkasse: 0 }
+    )
+
+    return { byMethod, registerTotals }
+  }, [payments, cashEntries])
+
+  const onPaymentSubmit = handleSubmit(({ orderId, amount, method }) => {
+    if (orderId.length === 0 || amount <= 0) return
+    recordPayment(orderId, amount, method, selectedRegister)
+    reset({ method: 'Bar', orderId: '', amount: 0 })
+  })
+
+  const onCashSubmit = handleCashSubmit(({ amount, method, note, type }) => {
+    if (amount <= 0) return
+    addCashEntry({ amount, method, note, type, register: selectedRegister })
+    resetCash({ amount: 0, method: 'Bar', note: '', type: 'Einzahlung' })
+  })
+
+  return (
+    <div className="module-grid">
+      <section className="card">
+        <header>
+          <h3>Kassensystem</h3>
+          <p>Zahlungen erfassen und Register verwalten.</p>
+        </header>
+        <div className="card-body column">
+          <div className="tab-group">
+            {(['Hauptkasse', 'Nebenkasse'] as const).map((register) => (
+              <button
+                key={register}
+                type="button"
+                className={register === selectedRegister ? 'tab active' : 'tab'}
+                onClick={() => selectRegister(register)}
+              >
+                {register}
+              </button>
+            ))}
+          </div>
+
+          <form className="form-grid" onSubmit={onPaymentSubmit}>
+            <Controller
+              control={control}
+              name="orderId"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <label className="field span-2">
+                  <span>Auftrag</span>
+                  <select {...field}>
+                    <option value="">Auswählen…</option>
+                    {orders.map((order) => (
+                      <option key={order.id} value={order.id}>
+                        {order.orderNumber} · {order.customer.name} · {formatCurrency(order.total)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="amount"
+              rules={{ required: true, min: 0.1 }}
+              render={({ field }) => (
+                <label className="field">
+                  <span>Betrag</span>
+                  <input type="number" min={0} step={0.1} {...field} />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="method"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Zahlart</span>
+                  <select {...field}>
+                    {paymentMethods.map((method) => (
+                      <option key={method} value={method}>
+                        {method}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            />
+            <div className="form-actions span-2">
+              <button type="submit" className="btn primary">
+                Zahlung erfassen
+              </button>
+            </div>
+          </form>
+
+          <div className="tile-grid">
+            {paymentMethods.map((method) => (
+              <div key={method} className="tile">
+                <span className="muted">{method}</span>
+                <strong>{formatCurrency(totals.byMethod[method])}</strong>
+              </div>
+            ))}
+          </div>
+
+          <form className="form-grid" onSubmit={onCashSubmit}>
+            <Controller
+              control={cashControl}
+              name="type"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Art</span>
+                  <select {...field}>
+                    <option value="Einzahlung">Einzahlung</option>
+                    <option value="Auszahlung">Auszahlung</option>
+                  </select>
+                </label>
+              )}
+            />
+            <Controller
+              control={cashControl}
+              name="amount"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Betrag</span>
+                  <input type="number" min={0} step={0.1} {...field} />
+                </label>
+              )}
+            />
+            <Controller
+              control={cashControl}
+              name="method"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Quelle</span>
+                  <select {...field}>
+                    {[...paymentMethods, 'Sonstiges'].map((method) => (
+                      <option key={method} value={method}>
+                        {method}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            />
+            <Controller
+              control={cashControl}
+              name="note"
+              render={({ field }) => (
+                <label className="field span-2">
+                  <span>Notiz</span>
+                  <input {...field} placeholder="Optional" />
+                </label>
+              )}
+            />
+            <div className="form-actions span-2">
+              <button type="submit" className="btn">
+                Manuelle Buchung
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card">
+        <header>
+          <h3>Kassenbuch</h3>
+          <p>Alle Buchungen nach Datum überblicken.</p>
+        </header>
+        <div className="card-body column">
+          <div className="tile-grid">
+            <div className="tile">
+              <span className="muted">Saldo Hauptkasse</span>
+              <strong>{formatCurrency(totals.registerTotals.Hauptkasse)}</strong>
+            </div>
+            <div className="tile">
+              <span className="muted">Saldo Nebenkasse</span>
+              <strong>{formatCurrency(totals.registerTotals.Nebenkasse)}</strong>
+            </div>
+          </div>
+          <div className="list">
+            {cashEntries.map((entry) => (
+              <article key={entry.id} className="list-item">
+                <div>
+                  <h4>{entry.type}</h4>
+                  <p className="muted">
+                    {format(new Date(entry.createdAt), 'dd.MM.yyyy HH:mm')} · {entry.register}
+                  </p>
+                  {entry.note != null && entry.note.length > 0 && <p className="muted">{entry.note}</p>}
+                </div>
+                <strong className={entry.type === 'Einzahlung' ? 'badge success' : 'badge danger'}>
+                  {entry.type === 'Einzahlung' ? '+' : '-'}{formatCurrency(entry.amount)}
+                </strong>
+              </article>
+            ))}
+            {cashEntries.length === 0 && <p className="muted">Noch keine Buchungen vorhanden.</p>}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default CashRegister

--- a/app/src/modules/complaints/ComplaintsModule.tsx
+++ b/app/src/modules/complaints/ComplaintsModule.tsx
@@ -1,0 +1,148 @@
+import { Controller, useForm } from 'react-hook-form'
+import { format } from 'date-fns'
+import { useDataStore } from '../../stores/useDataStore.js'
+import type { Complaint } from '../../types'
+
+interface ComplaintForm {
+  orderId?: string
+  reason: string
+  action: string
+  cost: number
+  notes?: string
+}
+
+const ComplaintsModule = (): JSX.Element => {
+  const orders = useDataStore((state) => state.orders)
+  const complaints = useDataStore((state) => state.complaints)
+  const addComplaint = useDataStore((state) => state.addComplaint)
+  const updateComplaintStatus = useDataStore((state) => state.updateComplaintStatus)
+  const { control, handleSubmit, reset } = useForm<ComplaintForm>({
+    defaultValues: { cost: 0 }
+  })
+
+  const onSubmit = handleSubmit((values) => {
+    addComplaint({ ...values, cost: Number(values.cost), status: 'offen' })
+    reset({ cost: 0 })
+  })
+
+  return (
+    <div className="module-grid">
+      <section className="card">
+        <header>
+          <h3>Reklamation erfassen</h3>
+          <p>Grund, Maßnahme, Status und Kosten dokumentieren.</p>
+        </header>
+        <div className="card-body">
+          <form className="form-grid" onSubmit={onSubmit}>
+            <Controller
+              control={control}
+              name="orderId"
+              render={({ field }) => (
+                <label className="field span-2">
+                  <span>Auftrag</span>
+                  <select {...field}>
+                    <option value="">Kein Auftrag</option>
+                    {orders.map((order) => (
+                      <option key={order.id} value={order.id}>
+                        {order.orderNumber} · {order.customer.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="reason"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <label className="field">
+                  <span>Grund</span>
+                  <input {...field} required />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="action"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <label className="field">
+                  <span>Maßnahme</span>
+                  <input {...field} required />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="cost"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Kosten</span>
+                  <input type="number" min={0} step={0.1} {...field} />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="notes"
+              render={({ field }) => (
+                <label className="field span-2">
+                  <span>Notizen</span>
+                  <textarea {...field} rows={3} placeholder="Zusätzliche Informationen" />
+                </label>
+              )}
+            />
+            <div className="form-actions span-2">
+              <button type="submit" className="btn primary">
+                Reklamation speichern
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card">
+        <header>
+          <h3>Reklamationsübersicht</h3>
+          <p>Bearbeitungsstand im Blick behalten.</p>
+        </header>
+        <div className="card-body column">
+          <div className="list">
+            {complaints.map((complaint) => (
+              <article key={complaint.id} className="list-item">
+                <div>
+                  <h4>{complaint.reason}</h4>
+                  <p className="muted">
+                    Maßnahme: {complaint.action} · Kosten: {complaint.cost.toFixed(2)} €
+                  </p>
+                  <p className="muted">
+                    Erstellt: {format(new Date(complaint.createdAt), 'dd.MM.yyyy HH:mm')} · Status: {complaint.status}
+                  </p>
+                  {complaint.notes != null && complaint.notes.length > 0 && (
+                    <p className="muted">Notizen: {complaint.notes}</p>
+                  )}
+                </div>
+                <div className="action-group">
+                  {(['offen', 'inBearbeitung', 'abgeschlossen'] as Complaint['status'][]).map((status) => (
+                    <button
+                      key={status}
+                      type="button"
+                      className={status === complaint.status ? 'btn primary' : 'btn'}
+                      onClick={() => updateComplaintStatus(complaint.id, status)}
+                    >
+                      {status}
+                    </button>
+                  ))}
+                </div>
+              </article>
+            ))}
+            {complaints.length === 0 && <p className="muted">Keine Reklamationen vorhanden.</p>}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default ComplaintsModule

--- a/app/src/modules/orders/OrderIntake.tsx
+++ b/app/src/modules/orders/OrderIntake.tsx
@@ -1,0 +1,245 @@
+import { useMemo, useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import { QRCodeCanvas } from 'qrcode.react'
+import { format } from 'date-fns'
+import { useDataStore } from '../../stores/useDataStore.js'
+import type { OrderLine, PriceItem } from '../../types'
+import { formatCurrency } from '../../utils/currency.js'
+import { usePrinter } from '../../hooks/usePrinter.js'
+import QrScanner from '../../components/QrScanner.js'
+
+interface FormValues {
+  customerName: string
+  customerPhone?: string
+  customerEmail?: string
+  pickupDate: string
+  notes?: string
+}
+
+const OrderIntake = (): JSX.Element => {
+  const priceList = useDataStore((state) => state.priceList)
+  const createOrder = useDataStore((state) => state.createOrder)
+  const [selectedItem, setSelectedItem] = useState<PriceItem | null>(null)
+  const [quantity, setQuantity] = useState(1)
+  const [lines, setLines] = useState<OrderLine[]>([])
+  const [qrScanResult, setQrScanResult] = useState('')
+  const { control, handleSubmit, reset } = useForm<FormValues>({
+    defaultValues: {
+      customerName: '',
+      pickupDate: new Date().toISOString().split('T')[0]
+    }
+  })
+  const { print } = usePrinter()
+
+  const total = useMemo(
+    () => lines.reduce((sum, line) => sum + line.price * line.quantity, 0),
+    [lines]
+  )
+
+  const addLine = () => {
+    if (selectedItem == null) return
+    const existing = lines.find((line) => line.itemId === selectedItem.id)
+    if (existing != null) {
+      setLines((prev) =>
+        prev.map((line) =>
+          line.itemId === selectedItem.id
+            ? { ...line, quantity: line.quantity + quantity }
+            : line
+        )
+      )
+    } else {
+      setLines((prev) => [...prev, { itemId: selectedItem.id, price: selectedItem.price, quantity }])
+    }
+    setQuantity(1)
+  }
+
+  const onSubmit = handleSubmit(({ customerName, customerPhone, customerEmail, pickupDate, notes }) => {
+    if (lines.length === 0) return
+
+    const order = createOrder({
+      customer: { id: crypto.randomUUID(), name: customerName, phone: customerPhone, email: customerEmail },
+      lines,
+      pickupDate: new Date(pickupDate).toISOString(),
+      notes
+    })
+
+    const receipt = `Auftrag ${order.orderNumber}\nKunde: ${order.customer.name}\nSumme: ${formatCurrency(order.total)}\nAbholung: ${format(
+      new Date(order.pickupDate),
+      'dd.MM.yyyy'
+    )}`
+    void print(receipt, { pageSize: 'A5' })
+
+    reset()
+    setLines([])
+  })
+
+  return (
+    <div className="module-grid">
+      <section className="card">
+        <header>
+          <h3>Auftragsannahme</h3>
+          <p>Preisliste durchsuchen, Stückzahl erfassen und Abholtermin festlegen.</p>
+        </header>
+        <div className="card-body">
+          <div className="form-grid">
+            <label className="field">
+              <span>Artikel</span>
+              <select value={selectedItem?.id ?? ''} onChange={(event) => {
+                const item = priceList.find((price) => price.id === event.target.value)
+                setSelectedItem(item ?? null)
+              }}>
+                <option value="">Auswählen…</option>
+                {priceList.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.name} · {formatCurrency(item.price)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="field">
+              <span>Stückzahl</span>
+              <input
+                type="number"
+                min={1}
+                value={quantity}
+                onChange={(event) => setQuantity(Number(event.target.value) || 1)}
+              />
+            </label>
+            <button type="button" className="btn primary" onClick={addLine} disabled={selectedItem == null}>
+              Position hinzufügen
+            </button>
+          </div>
+
+          <div className="lines-list">
+            {lines.map((line) => {
+              const item = priceList.find((price) => price.id === line.itemId)
+              if (item == null) return null
+              return (
+                <article key={line.itemId} className="line-entry">
+                  <div>
+                    <strong>{item.name}</strong>
+                    <span className="muted">{item.category}</span>
+                  </div>
+                  <div className="line-meta">
+                    <span className="muted">
+                      {line.quantity} × {formatCurrency(line.price)}
+                    </span>
+                    <strong>{formatCurrency(line.quantity * line.price)}</strong>
+                  </div>
+                </article>
+              )
+            })}
+            {lines.length === 0 && <p className="muted">Noch keine Position erfasst.</p>}
+          </div>
+
+          <form className="form-grid" onSubmit={onSubmit}>
+            <Controller
+              control={control}
+              name="customerName"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <label className="field">
+                  <span>Kund*in</span>
+                  <input {...field} placeholder="Name" required />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="customerPhone"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Telefon</span>
+                  <input {...field} placeholder="Optional" />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="customerEmail"
+              render={({ field }) => (
+                <label className="field">
+                  <span>E-Mail</span>
+                  <input type="email" {...field} placeholder="Optional" />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="pickupDate"
+              render={({ field }) => (
+                <label className="field">
+                  <span>Abholdatum</span>
+                  <input type="date" min={new Date().toISOString().split('T')[0]} {...field} />
+                </label>
+              )}
+            />
+            <Controller
+              control={control}
+              name="notes"
+              render={({ field }) => (
+                <label className="field span-2">
+                  <span>Notizen</span>
+                  <textarea {...field} rows={3} placeholder="Besondere Hinweise" />
+                </label>
+              )}
+            />
+            <div className="form-actions span-2">
+              <div className="total-display">Summe: {formatCurrency(total)}</div>
+              <div className="action-group">
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => void print('Label', { pageSize: { width: 57, height: 100 } })}
+                >
+                  Label 57 mm
+                </button>
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => void print('Label', { pageSize: { width: 80, height: 100 } })}
+                >
+                  Label 80 mm
+                </button>
+                <button type="submit" className="btn primary" disabled={lines.length === 0}>
+                  Auftrag speichern & drucken
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card">
+        <header>
+          <h3>QR & Zusammenfassung</h3>
+          <p>Übergabe erleichtern und Scans testen.</p>
+        </header>
+        <div className="card-body column">
+          <div className="qr-block">
+            <QRCodeCanvas value={qrScanResult || 'Textilreinigung Ettlingen'} size={220} bgColor="#0f172a" fgColor="#4db6ac" />
+            <p className="muted">Scannen Sie den Code am Tresen oder per Kunden-App.</p>
+          </div>
+          <div className="scanner-block">
+            <h4>Scanner</h4>
+            {typeof navigator !== 'undefined' && 'mediaDevices' in navigator ? (
+              <QrScanner onResult={(value) => setQrScanResult(value)} />
+            ) : (
+              <p className="muted">Scanner im aktuellen Kontext nicht verfügbar.</p>
+            )}
+            <p className="muted">Ergebnis: {qrScanResult || 'Noch kein Scan'}</p>
+          </div>
+          <div className="summary-block">
+            <h4>Heute</h4>
+            <p>
+              Positionen: <strong>{lines.length}</strong>
+            </p>
+            <p className="muted">Abholung: {format(new Date(), 'dd.MM.yyyy')}</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default OrderIntake

--- a/app/src/modules/orders/OrdersOverview.tsx
+++ b/app/src/modules/orders/OrdersOverview.tsx
@@ -1,0 +1,89 @@
+import { useMemo, useState } from 'react'
+import { format } from 'date-fns'
+import { useDataStore } from '../../stores/useDataStore.js'
+import type { OrderStatus } from '../../types'
+import { formatCurrency } from '../../utils/currency.js'
+
+const statusOptions: OrderStatus[] = ['offen', 'inBearbeitung', 'abholbereit', 'abgeholt']
+
+const OrdersOverview = (): JSX.Element => {
+  const orders = useDataStore((state) => state.orders)
+  const updateOrderStatus = useDataStore((state) => state.updateOrderStatus)
+  const [statusFilter, setStatusFilter] = useState<OrderStatus | 'alle'>('alle')
+  const [customerFilter, setCustomerFilter] = useState('')
+  const [dateFilter, setDateFilter] = useState('')
+
+  const filteredOrders = useMemo(() => {
+    return orders.filter((order) => {
+      const matchesStatus = statusFilter === 'alle' || order.status === statusFilter
+      const matchesCustomer =
+        customerFilter.length === 0 || order.customer.name.toLowerCase().includes(customerFilter.toLowerCase())
+      const matchesDate =
+        dateFilter.length === 0 || format(new Date(order.createdAt), 'yyyy-MM-dd') === dateFilter
+      return matchesStatus && matchesCustomer && matchesDate
+    })
+  }, [orders, statusFilter, customerFilter, dateFilter])
+
+  return (
+    <section className="card">
+      <header>
+        <h3>Auftragsübersicht</h3>
+        <p>Status verfolgen, filtern und Aufträge schnell aktualisieren.</p>
+      </header>
+      <div className="card-body column">
+        <div className="filter-grid">
+          <label className="field">
+            <span>Status</span>
+            <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as OrderStatus | 'alle')}>
+              <option value="alle">Alle</option>
+              {statusOptions.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Kund*in</span>
+            <input value={customerFilter} onChange={(event) => setCustomerFilter(event.target.value)} placeholder="Suche" />
+          </label>
+          <label className="field">
+            <span>Datum</span>
+            <input type="date" value={dateFilter} onChange={(event) => setDateFilter(event.target.value)} />
+          </label>
+        </div>
+
+        <div className="list">
+          {filteredOrders.map((order) => (
+            <article key={order.id} className="list-item">
+              <div>
+                <h4>{order.orderNumber}</h4>
+                <p className="muted">
+                  Kunde: {order.customer.name} · Auftragswert: {formatCurrency(order.total)}
+                </p>
+                <p className="muted">
+                  Erstellt: {format(new Date(order.createdAt), 'dd.MM.yyyy')} · Abholung: {format(new Date(order.pickupDate), 'dd.MM.yyyy')}
+                </p>
+              </div>
+              <div className="list-actions">
+                <select value={order.status} onChange={(event) => updateOrderStatus(order.id, event.target.value as OrderStatus)}>
+                  {statusOptions.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+                <span className={order.paymentStatus === 'bezahlt' ? 'badge success' : 'badge warning'}>
+                  {order.paymentStatus}
+                </span>
+              </div>
+            </article>
+          ))}
+          {filteredOrders.length === 0 && <p className="muted">Keine Aufträge gefunden.</p>}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default OrdersOverview

--- a/app/src/modules/statistics/StatisticsModule.tsx
+++ b/app/src/modules/statistics/StatisticsModule.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from 'react'
+import { useDataStore } from '../../stores/useDataStore.js'
+import type { StatisticsFilters } from '../../types'
+import { formatCurrency } from '../../utils/currency.js'
+
+const ranges: StatisticsFilters['range'][] = ['tag', 'woche', 'monat', 'quartal', 'jahr']
+
+const StatisticsModule = (): JSX.Element => {
+  const computeStatistics = useDataStore((state) => state.computeStatistics)
+  const orders = useDataStore((state) => state.orders)
+  const [filters, setFilters] = useState<StatisticsFilters>({ range: 'monat' })
+
+  const summary = useMemo(() => computeStatistics(filters), [computeStatistics, filters])
+
+  return (
+    <section className="card">
+      <header>
+        <h3>Statistiken</h3>
+        <p>Zeitraum wählen und Kennzahlen analysieren.</p>
+      </header>
+      <div className="card-body column">
+        <div className="filter-grid">
+          <label className="field">
+            <span>Zeitraum</span>
+            <select
+              value={filters.range}
+              onChange={(event) => setFilters((prev) => ({ ...prev, range: event.target.value as StatisticsFilters['range'] }))}
+            >
+              {ranges.map((range) => (
+                <option key={range} value={range}>
+                  {range}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Von</span>
+            <input
+              type="date"
+              value={filters.from ?? ''}
+              onChange={(event) => setFilters((prev) => ({ ...prev, from: event.target.value }))}
+            />
+          </label>
+          <label className="field">
+            <span>Bis</span>
+            <input
+              type="date"
+              value={filters.to ?? ''}
+              onChange={(event) => setFilters((prev) => ({ ...prev, to: event.target.value }))}
+            />
+          </label>
+        </div>
+
+        <div className="tile-grid">
+          <div className="tile">
+            <span className="muted">Umsatz</span>
+            <strong>{formatCurrency(summary.revenue)}</strong>
+          </div>
+          <div className="tile">
+            <span className="muted">Aufträge</span>
+            <strong>{summary.orderCount}</strong>
+          </div>
+          <div className="tile">
+            <span className="muted">Ø Auftragswert</span>
+            <strong>{formatCurrency(summary.averageOrderValue)}</strong>
+          </div>
+          <div className="tile">
+            <span className="muted">Artikelanzahl</span>
+            <strong>{summary.itemsProcessed}</strong>
+          </div>
+        </div>
+
+        <div className="tile-grid">
+          <div className="tile">
+            <span className="muted">Provision 45%</span>
+            <strong>{formatCurrency(summary.provision45)}</strong>
+          </div>
+          <div className="tile">
+            <span className="muted">Provision 55%</span>
+            <strong>{formatCurrency(summary.provision55)}</strong>
+          </div>
+        </div>
+
+        <div className="list">
+          {Object.entries(summary.revenueByCategory).map(([category, value]) => (
+            <article key={category} className="list-item">
+              <div>
+                <h4>{category}</h4>
+                <p className="muted">Kategorieumsatz</p>
+              </div>
+              <strong>{formatCurrency(Number(value) || 0)}</strong>
+            </article>
+          ))}
+        </div>
+
+        <p className="muted">{orders.length} Aufträge insgesamt gespeichert.</p>
+      </div>
+    </section>
+  )
+}
+
+export default StatisticsModule

--- a/app/src/services/dataRepository.ts
+++ b/app/src/services/dataRepository.ts
@@ -1,0 +1,76 @@
+import type { PersistedState } from '../types'
+import { firebaseRepository } from './firebaseClient.js'
+
+const STORAGE_KEY = 'textilreinigung-ettlingen-state'
+
+const defaultState: PersistedState = {
+  orders: [],
+  payments: [],
+  complaints: [],
+  cashEntries: []
+}
+
+export class DataRepository {
+  async load(): Promise<PersistedState> {
+    const local = this.loadLocal()
+
+    if (firebaseRepository.enabled) {
+      try {
+        const remote = await firebaseRepository.load()
+        return {
+          ...defaultState,
+          ...local,
+          ...remote
+        }
+      } catch (error) {
+        console.warn('Firestore laden fehlgeschlagen', error)
+      }
+    }
+
+    return { ...defaultState, ...local }
+  }
+
+  async save(partial: Partial<PersistedState>): Promise<void> {
+    const current = this.loadLocal()
+    const merged: PersistedState = {
+      ...current,
+      ...partial
+    }
+
+    this.saveLocal(merged)
+
+    if (firebaseRepository.enabled) {
+      await Promise.all(
+        (Object.keys(partial) as (keyof PersistedState)[]).map(async (key) => {
+          const data = merged[key]
+          await firebaseRepository.save(key, data)
+        })
+      )
+    }
+  }
+
+  private loadLocal(): PersistedState {
+    if (typeof window === 'undefined') {
+      return defaultState
+    }
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (raw == null) {
+        return defaultState
+      }
+      const parsed = JSON.parse(raw) as PersistedState
+      return { ...defaultState, ...parsed }
+    } catch (error) {
+      console.warn('Konnte lokalen Zustand nicht lesen', error)
+      return defaultState
+    }
+  }
+
+  private saveLocal(state: PersistedState): void {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  }
+}
+
+export const dataRepository = new DataRepository()

--- a/app/src/services/firebaseClient.ts
+++ b/app/src/services/firebaseClient.ts
@@ -1,0 +1,111 @@
+import type { PersistedState } from '../types'
+
+interface FirestoreConfig {
+  apiKey: string
+  authDomain: string
+  projectId: string
+  storageBucket?: string
+  messagingSenderId?: string
+  appId?: string
+}
+
+export class FirebaseRepository {
+  private app?: any
+  private db?: any
+  private firestoreApi?: {
+    collection: any
+    getDocs: any
+    setDoc: any
+    doc: any
+  }
+  private readonly config?: FirestoreConfig
+  private initialized = false
+  private initPromise?: Promise<void>
+
+  constructor() {
+    const configEnv = typeof process !== 'undefined' ? process.env?.FIREBASE_CONFIG ?? '' : ''
+
+    if (configEnv.length === 0) {
+      this.initialized = true
+      return
+    }
+
+    try {
+      this.config = JSON.parse(configEnv) as FirestoreConfig
+    } catch (error) {
+      console.warn('Konnte Firebase-Konfiguration nicht lesen', error)
+      this.initialized = true
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return
+    if (this.initPromise) {
+      await this.initPromise
+      return
+    }
+
+    if (this.config == null) {
+      this.initialized = true
+      return
+    }
+
+    this.initPromise = (async () => {
+      try {
+        const [{ initializeApp }, firestore] = await Promise.all([
+          import('firebase/app'),
+          import('firebase/firestore')
+        ])
+
+        this.app = initializeApp(this.config)
+        this.db = firestore.getFirestore(this.app)
+        this.firestoreApi = {
+          collection: firestore.collection,
+          getDocs: firestore.getDocs,
+          setDoc: firestore.setDoc,
+          doc: firestore.doc
+        }
+      } catch (error) {
+        console.warn('Konnte Firebase nicht initialisieren', error)
+      } finally {
+        this.initialized = true
+      }
+    })()
+
+    await this.initPromise
+  }
+
+  get enabled(): boolean {
+    return this.config != null
+  }
+
+  async load(): Promise<Partial<PersistedState>> {
+    await this.ensureInitialized()
+    if (this.db == null || this.firestoreApi == null) return {}
+
+    const collections = ['orders', 'payments', 'complaints', 'cashEntries'] as const
+    const result: Partial<PersistedState> = {}
+
+    for (const col of collections) {
+      const snapshot = await this.firestoreApi.getDocs(this.firestoreApi.collection(this.db, col))
+      result[col] = snapshot.docs.map((doc) => doc.data()) as any
+    }
+
+    return result
+  }
+
+  async save(collectionName: keyof PersistedState, data: PersistedState[typeof collectionName]): Promise<void> {
+    await this.ensureInitialized()
+    if (this.db == null || this.firestoreApi == null) return
+
+    const targetCollection = this.firestoreApi.collection(this.db, collectionName)
+    const batch = data.map(async (item) => {
+      const document = this.firestoreApi!.doc(targetCollection, item.id)
+      await this.firestoreApi!.setDoc(document, item)
+    })
+
+    await Promise.all(batch)
+  }
+}
+
+export const firebaseRepository = new FirebaseRepository()

--- a/app/src/shims.d.ts
+++ b/app/src/shims.d.ts
@@ -1,0 +1,71 @@
+declare module 'react' {
+  export type ReactNode = any
+  export function useState<T = any>(initial: T): [T, (value: T | ((prev: T) => T)) => void]
+  export function useEffect(effect: () => void | (() => void), deps?: any[]): void
+  export function useMemo<T>(factory: () => T, deps: any[]): T
+  export function useCallback<T extends (...args: any[]) => any>(fn: T, deps: any[]): T
+  const React: any
+  export default React
+}
+
+declare module 'react/jsx-runtime' {
+  export const jsx: any
+  export const jsxs: any
+  export const Fragment: any
+}
+
+declare module 'react-dom/client' {
+  export function createRoot(container: any): { render: (node: any) => void }
+}
+
+declare module 'react-hook-form' {
+  export const Controller: any
+  export function useForm<T>(options?: any): any
+}
+
+declare module 'date-fns' {
+  export function format(date: Date, formatStr: string): string
+}
+
+declare module 'html5-qrcode' {
+  export class Html5Qrcode {
+    constructor(elementId: string)
+    start(camera: any, config: any, onSuccess: (decodedText: string) => void): Promise<void>
+    stop(): Promise<void>
+    clear(): void
+  }
+}
+
+declare module 'qrcode.react' {
+  export const QRCodeCanvas: any
+}
+
+declare module 'firebase/app' {
+  export const initializeApp: any
+  export type FirebaseApp = any
+}
+
+declare module 'firebase/firestore' {
+  export const getFirestore: any
+  export type Firestore = any
+  export const collection: any
+  export const getDocs: any
+  export const setDoc: any
+  export const doc: any
+}
+
+declare module 'zustand' {
+  export function create<T>(initializer?: any): any
+}
+
+declare module 'zustand/middleware' {
+  export const devtools: any
+}
+
+declare const process: any
+
+declare namespace Electron {
+  interface WebContentsPrintOptions {
+    [key: string]: any
+  }
+}

--- a/app/src/stores/createStore.ts
+++ b/app/src/stores/createStore.ts
@@ -1,0 +1,41 @@
+export type SetState<T> = (partial: Partial<T> | ((state: T) => Partial<T>), replace?: boolean) => void
+export type GetState<T> = () => T
+export type StateCreator<T> = (set: SetState<T>, get: GetState<T>) => T
+
+type Listener<T> = (state: T) => void
+
+export const createStore = <T>(creator: StateCreator<T>) => {
+  let state: T
+  let baseState: T
+  const listeners = new Set<Listener<T>>()
+
+  const setState: SetState<T> = (partial, replace = false) => {
+    const nextPartial = typeof partial === 'function' ? partial(state) : partial
+    state = replace ? ({ ...baseState, ...nextPartial } as T) : { ...state, ...nextPartial }
+    listeners.forEach((listener) => listener(state))
+  }
+
+  const getState: GetState<T> = () => state
+
+  const subscribe = (listener: Listener<T>) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }
+
+  const api = (selector?: (state: T) => any) => (selector != null ? selector(state) : state)
+
+  api.getState = getState
+  api.setState = (partial: Partial<T> | ((state: T) => Partial<T>), replace = false) => {
+    setState(partial, replace)
+  }
+  api.subscribe = subscribe
+
+  state = creator(setState, getState)
+  baseState = { ...state }
+
+  return api as typeof api & {
+    getState: GetState<T>
+    setState: SetState<T>
+    subscribe: (listener: Listener<T>) => () => void
+  }
+}

--- a/app/src/stores/useDataStore.ts
+++ b/app/src/stores/useDataStore.ts
@@ -1,0 +1,287 @@
+import { createStore } from './createStore.js'
+import { dataRepository } from '../services/dataRepository.js'
+import { generateOrderNumber } from '../utils/orders.js'
+import type {
+  CashEntry,
+  Complaint,
+  Customer,
+  Order,
+  OrderLine,
+  Payment,
+  PaymentMethod,
+  PriceItem,
+  StatisticsFilters,
+  StatisticsSummary
+} from '../types'
+
+const priceList: PriceItem[] = [
+  { id: 'anzug', name: 'Anzug 2-teilig', price: 14.5, category: 'Reinigung' },
+  { id: 'hemd', name: 'Hemd', price: 2.8, category: 'Wäsche' },
+  { id: 'vorhang', name: 'Vorhang', price: 12.9, category: 'Service' },
+  { id: 'impragnierung', name: 'Imprägnierung', price: 9.5, category: 'Extras' },
+  { id: 'verkauf-buerste', name: 'Kleiderbürste', price: 6.5, category: 'Verkauf' }
+]
+
+type Register = 'Hauptkasse' | 'Nebenkasse'
+
+interface DataStoreState {
+  priceList: PriceItem[]
+  orders: Order[]
+  payments: Payment[]
+  complaints: Complaint[]
+  cashEntries: CashEntry[]
+  selectedRegister: Register
+  loadInitialData: () => Promise<void>
+  createOrder: (input: {
+    customer: Customer
+    lines: OrderLine[]
+    pickupDate: string
+    notes?: string
+  }) => Order
+  updateOrderStatus: (orderId: string, status: Order['status']) => void
+  recordPayment: (orderId: string, amount: number, method: PaymentMethod, register: Register) => void
+  addComplaint: (complaint: Omit<Complaint, 'id' | 'createdAt'>) => Complaint
+  updateComplaintStatus: (id: string, status: Complaint['status']) => void
+  addCashEntry: (entry: Omit<CashEntry, 'id' | 'createdAt'>) => CashEntry
+  selectRegister: (register: Register) => void
+  computeStatistics: (filters: StatisticsFilters) => StatisticsSummary
+}
+
+const defaultSummary: StatisticsSummary = {
+  revenue: 0,
+  orderCount: 0,
+  averageOrderValue: 0,
+  provision45: 0,
+  provision55: 0,
+  revenueByCategory: {
+    Reinigung: 0,
+    Wäsche: 0,
+    Extras: 0,
+    Service: 0,
+    Verkauf: 0
+  },
+  itemsProcessed: 0
+}
+
+export const useDataStore = createStore<DataStoreState>((set, get) => ({
+    priceList,
+    orders: [],
+    payments: [],
+    complaints: [],
+    cashEntries: [],
+    selectedRegister: 'Hauptkasse',
+    loadInitialData: async () => {
+      const persisted = await dataRepository.load()
+      set({
+        orders: persisted.orders,
+        payments: persisted.payments,
+        complaints: persisted.complaints,
+        cashEntries: persisted.cashEntries
+      })
+    },
+    createOrder: ({ customer, lines, pickupDate, notes }) => {
+      const total = lines.reduce((sum, line) => sum + line.price * line.quantity, 0)
+      const orderNumber = generateOrderNumber()
+      const order: Order = {
+        id: crypto.randomUUID(),
+        orderNumber,
+        createdAt: new Date().toISOString(),
+        pickupDate,
+        status: 'offen',
+        customer,
+        lines,
+        total,
+        paymentStatus: 'offen',
+        qrCode: JSON.stringify({
+          orderNumber,
+          pickupDate,
+          customer: customer.name
+        }),
+        notes
+      }
+
+      set((state) => {
+        const orders = [...state.orders, order]
+        void dataRepository.save({ orders })
+        return { orders }
+      })
+
+      return order
+    },
+    updateOrderStatus: (orderId, status) => {
+      set((state) => {
+        const orders = state.orders.map((order) =>
+          order.id === orderId
+            ? {
+                ...order,
+                status
+              }
+            : order
+        )
+        void dataRepository.save({ orders })
+        return { orders }
+      })
+    },
+    recordPayment: (orderId, amount, method, register) => {
+      const payment: Payment = {
+        id: crypto.randomUUID(),
+        orderId,
+        amount,
+        method,
+        createdAt: new Date().toISOString(),
+        register,
+        notes: register === 'Nebenkasse' ? 'Nebenkasse' : undefined
+      }
+
+      set((state) => {
+        const payments = [...state.payments, payment]
+        const orders = state.orders.map((order) => {
+          if (order.id !== orderId) return order
+          const alreadyPaid = state.payments
+            .filter((p) => p.orderId === orderId)
+            .reduce((sum, p) => sum + p.amount, 0)
+          const newTotal = alreadyPaid + amount
+          const paymentStatus: Order['paymentStatus'] = newTotal >= order.total ? 'bezahlt' : 'teilweise'
+          return {
+            ...order,
+            paymentStatus,
+            paymentMethod: method
+          }
+        })
+
+        const cashEntry: CashEntry = {
+          id: payment.id,
+          type: 'Einzahlung',
+          amount,
+          method,
+          createdAt: payment.createdAt,
+          register,
+          note: payment.notes
+        }
+        const cashEntries = [...state.cashEntries, cashEntry]
+
+        void dataRepository.save({ payments, orders, cashEntries })
+        return { payments, orders, cashEntries }
+      })
+    },
+    addComplaint: (complaint) => {
+      const record: Complaint = {
+        ...complaint,
+        id: crypto.randomUUID(),
+        createdAt: new Date().toISOString()
+      }
+      set((state) => {
+        const complaints = [...state.complaints, record]
+        void dataRepository.save({ complaints })
+        return { complaints }
+      })
+      return record
+    },
+    updateComplaintStatus: (id, status) => {
+      set((state) => {
+        const complaints = state.complaints.map((complaint) =>
+          complaint.id === id
+            ? {
+                ...complaint,
+                status
+              }
+            : complaint
+        )
+        void dataRepository.save({ complaints })
+        return { complaints }
+      })
+    },
+    addCashEntry: (entry) => {
+      const cashEntry: CashEntry = {
+        ...entry,
+        id: crypto.randomUUID(),
+        createdAt: new Date().toISOString()
+      }
+      set((state) => {
+        const cashEntries = [...state.cashEntries, cashEntry]
+        void dataRepository.save({ cashEntries })
+        return { cashEntries }
+      })
+      return cashEntry
+    },
+    selectRegister: (register) => set({ selectedRegister: register }),
+    computeStatistics: (filters) => {
+      const { orders, payments } = get()
+      if (orders.length === 0) return defaultSummary
+
+      const now = new Date()
+      let start = new Date()
+      switch (filters.range) {
+        case 'tag':
+          start.setHours(0, 0, 0, 0)
+          break
+        case 'woche':
+          start.setDate(now.getDate() - 7)
+          break
+        case 'monat':
+          start.setMonth(now.getMonth() - 1)
+          break
+        case 'quartal':
+          start.setMonth(now.getMonth() - 3)
+          break
+        case 'jahr':
+          start.setFullYear(now.getFullYear() - 1)
+          break
+      }
+
+      const end = filters.to != null ? new Date(filters.to) : now
+      if (filters.from != null) {
+        start = new Date(filters.from)
+      }
+
+      const inRange = orders.filter((order) => {
+        const created = new Date(order.createdAt)
+        return created >= start && created <= end
+      })
+
+      if (inRange.length === 0) {
+        return defaultSummary
+      }
+
+      const revenue = inRange.reduce((sum, order) => sum + order.total, 0)
+      const orderCount = inRange.length
+      const averageOrderValue = revenue / orderCount
+      const provision45 = revenue * 0.45
+      const provision55 = revenue * 0.55
+
+      const revenueByCategory = inRange.reduce((acc, order) => {
+        order.lines.forEach((line) => {
+          const item = priceList.find((p) => p.id === line.itemId)
+          if (item != null) {
+            acc[item.category] += line.price * line.quantity
+          }
+        })
+        return acc
+      },
+      {
+        Reinigung: 0,
+        Wäsche: 0,
+        Extras: 0,
+        Service: 0,
+        Verkauf: 0
+      } as StatisticsSummary['revenueByCategory'])
+
+      const itemsProcessed = inRange.reduce(
+        (sum, order) => sum + order.lines.reduce((count, line) => count + line.quantity, 0),
+        0
+      )
+
+      return {
+        revenue,
+        orderCount,
+        averageOrderValue,
+        provision45,
+        provision55,
+        revenueByCategory,
+        itemsProcessed
+      }
+    }
+}))
+
+export type { PriceItem }
+export type { StatisticsSummary }

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -1,0 +1,402 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #0f172a, #020617);
+  min-height: 100vh;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.app-sidebar {
+  width: 280px;
+  background: rgba(15, 23, 42, 0.95);
+  border-right: 1px solid rgba(148, 163, 184, 0.1);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: relative;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sidebar-logo {
+  font-size: 2.5rem;
+}
+
+.sidebar-toggle {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.8rem;
+  display: none;
+}
+
+.app-sidebar nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 1.1rem;
+  border-radius: 14px;
+  color: inherit;
+  text-decoration: none;
+  font-size: 1.05rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+  border: none;
+  background: transparent;
+  width: 100%;
+  text-align: left;
+}
+
+.nav-link:hover {
+  background: rgba(148, 163, 184, 0.15);
+  transform: translateX(4px);
+}
+
+.nav-link.active {
+  background: linear-gradient(90deg, rgba(77, 182, 172, 0.3), rgba(56, 189, 248, 0.25));
+  color: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.nav-icon {
+  font-size: 1.6rem;
+}
+
+.app-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 2.5rem 3rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.app-view {
+  padding: 2rem 3rem 3rem;
+  flex: 1;
+}
+
+.module-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+}
+
+.card header {
+  margin-bottom: 1.5rem;
+}
+
+.card header h3 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.card header p {
+  margin: 0.35rem 0 0;
+  color: #94a3b8;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card-body.column {
+  gap: 2rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: end;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.field span {
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.field input,
+.field select,
+.field textarea {
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(2, 6, 23, 0.6);
+  color: inherit;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.span-2 {
+  grid-column: span 2;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.action-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  border: none;
+  border-radius: 16px;
+  padding: 0.85rem 1.4rem;
+  background: rgba(51, 65, 85, 0.6);
+  color: #e2e8f0;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 118, 110, 0.25);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #0ea5e9, #14b8a6);
+  color: #f8fafc;
+}
+
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.lines-list,
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.line-entry,
+.list-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 1.1rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.line-meta,
+.list-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.list-actions select,
+.tab-group .tab,
+.total-display {
+  font-size: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  text-transform: capitalize;
+}
+
+.badge.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.badge.warning {
+  background: rgba(251, 191, 36, 0.2);
+  color: #facc15;
+}
+
+.badge.danger {
+  background: rgba(239, 68, 68, 0.25);
+  color: #fca5a5;
+}
+
+.muted {
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.total-display {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.qr-block,
+.summary-block,
+.scanner-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+  text-align: center;
+}
+
+.tile-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.tile {
+  padding: 1.2rem;
+  border-radius: 18px;
+  background: rgba(15, 118, 110, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: 1px solid rgba(20, 184, 166, 0.2);
+}
+
+.tab-group {
+  display: inline-flex;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.7);
+  padding: 0.6rem;
+  border-radius: 999px;
+}
+
+.tab {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.tab.active {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.3), rgba(20, 184, 166, 0.35));
+  color: #f8fafc;
+}
+
+.filter-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.app-sidebar.open {
+  position: fixed;
+  z-index: 20;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .app-sidebar {
+    position: fixed;
+    inset: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 10;
+  }
+
+  .app-sidebar.open {
+    transform: translateX(0);
+  }
+
+  .sidebar-toggle {
+    display: block;
+  }
+
+  .app-content {
+    margin-left: 0;
+  }
+
+  .app-header,
+  .app-view {
+    padding: 1.5rem;
+  }
+}
+
+::-webkit-scrollbar {
+  width: 12px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 8px;
+}

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,0 +1,93 @@
+export type OrderStatus = 'offen' | 'inBearbeitung' | 'abholbereit' | 'abgeholt'
+
+export interface PriceItem {
+  id: string
+  name: string
+  category: 'Reinigung' | 'Wäsche' | 'Extras' | 'Service' | 'Verkauf'
+  price: number
+}
+
+export interface OrderLine {
+  itemId: string
+  quantity: number
+  price: number
+  notes?: string
+}
+
+export interface Customer {
+  id: string
+  name: string
+  phone?: string
+  email?: string
+}
+
+export interface Order {
+  id: string
+  orderNumber: string
+  createdAt: string
+  pickupDate: string
+  status: OrderStatus
+  customer: Customer
+  lines: OrderLine[]
+  total: number
+  paymentStatus: 'offen' | 'teilweise' | 'bezahlt'
+  paymentMethod?: PaymentMethod
+  qrCode: string
+  notes?: string
+}
+
+export type PaymentMethod = 'Bar' | 'EC' | 'Bank' | 'Wise' | 'Kreditkarte'
+
+export interface Payment {
+  id: string
+  orderId?: string
+  amount: number
+  method: PaymentMethod
+  createdAt: string
+  notes?: string
+  register: 'Hauptkasse' | 'Nebenkasse'
+}
+
+export interface Complaint {
+  id: string
+  orderId?: string
+  reason: string
+  action: string
+  status: 'offen' | 'inBearbeitung' | 'abgeschlossen'
+  cost: number
+  notes?: string
+  createdAt: string
+}
+
+export interface CashEntry {
+  id: string
+  type: 'Einzahlung' | 'Auszahlung'
+  amount: number
+  method: PaymentMethod | 'Sonstiges'
+  createdAt: string
+  register: 'Hauptkasse' | 'Nebenkasse'
+  note?: string
+}
+
+export interface StatisticsFilters {
+  range: 'tag' | 'woche' | 'monat' | 'quartal' | 'jahr'
+  from?: string
+  to?: string
+}
+
+export interface StatisticsSummary {
+  revenue: number
+  orderCount: number
+  averageOrderValue: number
+  provision45: number
+  provision55: number
+  revenueByCategory: Record<PriceItem['category'], number>
+  itemsProcessed: number
+}
+
+export interface PersistedState {
+  orders: Order[]
+  payments: Payment[]
+  complaints: Complaint[]
+  cashEntries: CashEntry[]
+}

--- a/app/src/utils/classNames.ts
+++ b/app/src/utils/classNames.ts
@@ -1,0 +1,2 @@
+export const classNames = (...values: Array<string | false | null | undefined>): string =>
+  values.filter(Boolean).join(' ')

--- a/app/src/utils/currency.ts
+++ b/app/src/utils/currency.ts
@@ -1,0 +1,5 @@
+export const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR'
+  }).format(value)

--- a/app/src/utils/orders.ts
+++ b/app/src/utils/orders.ts
@@ -1,0 +1,10 @@
+export const generateOrderNumber = (date = new Date()): string => {
+  const year = date.getFullYear().toString().slice(-2)
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+  const random = Math.floor(Math.random() * 999)
+    .toString()
+    .padStart(3, '0')
+
+  return `${year}${month}${day}-${random}`
+}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/tests/useDataStore.test.js
+++ b/app/tests/useDataStore.test.js
@@ -1,0 +1,68 @@
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+const repoModule = await import('../dist/services/dataRepository.js')
+const { useDataStore } = await import('../dist/stores/useDataStore.js')
+
+const initial = {
+  orders: [],
+  payments: [],
+  complaints: [],
+  cashEntries: []
+}
+
+repoModule.dataRepository.load = async () => ({ ...initial })
+repoModule.dataRepository.save = async () => {}
+
+beforeEach(() => {
+  const current = useDataStore.getState()
+  useDataStore.setState({
+    priceList: current.priceList,
+    orders: [],
+    payments: [],
+    complaints: [],
+    cashEntries: [],
+    selectedRegister: 'Hauptkasse'
+  }, true)
+})
+
+test('creates order with correct total', () => {
+  const store = useDataStore.getState()
+  const order = store.createOrder({
+    customer: { id: '1', name: 'Anna Muster' },
+    pickupDate: new Date().toISOString(),
+    lines: [
+      { itemId: store.priceList[0].id, quantity: 2, price: store.priceList[0].price },
+      { itemId: store.priceList[1].id, quantity: 1, price: store.priceList[1].price }
+    ]
+  })
+
+  assert.ok(order.total > 0)
+  assert.equal(useDataStore.getState().orders.length, 1)
+})
+
+test('marks order as paid after payment', () => {
+  const store = useDataStore.getState()
+  const order = store.createOrder({
+    customer: { id: '1', name: 'Karl Kunde' },
+    pickupDate: new Date().toISOString(),
+    lines: [{ itemId: store.priceList[0].id, quantity: 1, price: store.priceList[0].price }]
+  })
+
+  store.recordPayment(order.id, order.total, 'Bar', 'Hauptkasse')
+
+  const updated = useDataStore.getState().orders.find((entry) => entry.id === order.id)
+  assert.equal(updated?.paymentStatus, 'bezahlt')
+})
+
+test('computes statistics with positive revenue', () => {
+  const store = useDataStore.getState()
+  store.createOrder({
+    customer: { id: '1', name: 'Statistik Star' },
+    pickupDate: new Date().toISOString(),
+    lines: [{ itemId: store.priceList[0].id, quantity: 1, price: store.priceList[0].price }]
+  })
+
+  const stats = store.computeStatistics({ range: 'jahr' })
+  assert.ok(stats.revenue >= 0)
+})

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "types": [],
+    "outDir": "dist",
+    "rootDir": "src",
+    "noImplicitAny": false
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist-electron"
+  },
+  "include": ["electron"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  esbuild: {
+    jsxInject: "import React from 'react'",
+    jsxFactory: 'React.createElement',
+    jsxFragment: 'React.Fragment'
+  },
+  build: {
+    outDir: 'dist'
+  }
+})

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts'
+  },
+  esbuild: {
+    jsxInject: "import React from 'react'"
+  }
+})

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -1,0 +1,3 @@
+beforeEach(() => {
+  localStorage.clear()
+})


### PR DESCRIPTION
## Summary
- add an Electron + React touch-optimised desktop interface with navigation across order intake, overview, cash desk, complaints, and statistics modules
- implement a persistent data store with optional Firestore sync, local storage fallback, and bespoke state manager utilities
- provide node-based unit tests for the data store and ignore build artefacts in version control

## Testing
- npm run build:ts
- node --test tests/useDataStore.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd038f3738832687acf098aed46d7c